### PR TITLE
RF_POM | contactPage.spec | TC 06.01.16 Verify that the "E-mail" fiel…

### DIFF
--- a/page_objects/contactsPage.js
+++ b/page_objects/contactsPage.js
@@ -16,7 +16,7 @@ class ContactsPage {
 		getSendButton: () => this.page.getByRole('button', { name: 'Відправити' }),
 		getMessageRequired: () => this.page.getByText('Поле обовʼязкове до заповнення').first(),
 		getEmailField: () => this.page.getByPlaceholder('E-mail'),
-		getMessageEmailField: () => this.page.getByText('Будь ласка, введіть дійсну адресу електронної пошти')
+		getMessageEmailField: () => this.page.getByText('Будь ласка, введіть дійсну адресу електронної пошти.')
 
 
 
@@ -67,6 +67,27 @@ class ContactsPage {
 		await this.locators.getEmailField().fill('sUn@gmai.c-om');
 
 	}
+
+	async fillwithoutAtEmailField() {
+		await this.locators.getEmailField().fill('sUngmai.com');
+
+	}
+
+	async fillwithAtAtEmailField() {
+		await this.locators.getEmailField().fill('sUnn@@gmai.com');
+
+	}
+
+	async fillwithDatEmailField() {
+		await this.locators.getEmailField().fill('sUn..n@gmai.com');
+
+	}
+
+	async fillwithoutNameEmailField() {
+		await this.locators.getEmailField().fill('@gmai.com');
+
+	}
+
 
 
 }

--- a/tests/test_page_objects/contactPage.spec.js
+++ b/tests/test_page_objects/contactPage.spec.js
@@ -106,6 +106,38 @@ test('TC 06.01.5 Verify that the  "Имя" field does not accept numbers, a vali
 
     });
 
+    test('TC 06.01.16 Verify that the "E-mail" field does not accept an email without the @ symbol, a warning message has been received', async ({ page }) => {
+        const contactPage = new ContactsPage(page);
+        await contactPage.fillwithoutAtEmailField();
+        await contactPage.clickSendButton();
+        await expect(contactPage.locators.getMessageEmailField()).toBeTruthy();
+
+
+    });
+
+    test('TC 06.01.17 Verify that the "E-mail" field does not accept an email with 2 @ symbol, a warning message has been received', async ({ page }) => {
+        const contactPage = new ContactsPage(page);
+        await contactPage.fillwithAtAtEmailField();
+        await contactPage.clickSendButton();
+        await expect(contactPage.locators.getMessageEmailField()).toBeTruthy();
+
+    });
+
+    test('TC 06.01.18 Verify that the "E-mail" field does not accept an email with two dots in a row in the user name', async ({ page }) => {
+        const contactPage = new ContactsPage(page);
+        await contactPage.fillwithDatEmailField();
+        await contactPage.clickSendButton();
+        await expect(contactPage.locators.getMessageEmailField()).toBeTruthy();
+
+    });
+
+    test('TC 06.01.20 Verify that the"E-mail" field does not accept an email without a username', async ({ page }) => {
+        const contactPage = new ContactsPage(page);
+        await contactPage.fillwithoutNameEmailField();
+        await contactPage.clickSendButton();
+        await expect(contactPage.locators.getMessageEmailField()).toBeTruthy();
+
+    });
 
 })
 


### PR DESCRIPTION
…d does not accept an email without the @ symbol, a warning message has been received, TC 06.01.17 Verify that the "E-mail" field does not accept an email with 2 @ symbol, a warning message has been received, TC 06.01.18 Verify that the "E-mail" field does not accept an email with two dots in a row in the user name, TC 06.01.20 Verify that the"E-mail" field does not accept an email without a username